### PR TITLE
COM-2377: change nomenclature

### DIFF
--- a/src/helpers/steps.js
+++ b/src/helpers/steps.js
@@ -4,7 +4,7 @@ const moment = require('../extensions/moment');
 const UtilsHelper = require('./utils');
 const { E_LEARNING } = require('./constants');
 
-const ON_SITE_PROGRESS_WEIGHT = 0.9;
+const LIVE_PROGRESS_WEIGHT = 0.9;
 
 exports.updateStep = async (stepId, payload) => Step.updateOne({ _id: stepId }, { $set: payload });
 
@@ -26,16 +26,16 @@ exports.elearningStepProgress = (step) => {
   return maxProgress ? progress / maxProgress : 0;
 };
 
-exports.onSiteStepProgress = (step, slots) => {
+exports.liveStepProgress = (step, slots) => {
   const nextSlots = slots.filter(slot => moment().isSameOrBefore(slot.endDate));
-  const onSiteProgress = slots.length ? 1 - nextSlots.length / slots.length : 0;
+  const liveProgress = slots.length ? 1 - nextSlots.length / slots.length : 0;
 
   return step.activities.length
-    ? parseFloat((onSiteProgress * ON_SITE_PROGRESS_WEIGHT
-        + exports.elearningStepProgress(step) * (1 - ON_SITE_PROGRESS_WEIGHT)).toFixed(2))
-    : onSiteProgress;
+    ? parseFloat((liveProgress * LIVE_PROGRESS_WEIGHT
+        + exports.elearningStepProgress(step) * (1 - LIVE_PROGRESS_WEIGHT)).toFixed(2))
+    : liveProgress;
 };
 
 exports.getProgress = (step, slots) => (step.type === E_LEARNING
   ? exports.elearningStepProgress(step)
-  : exports.onSiteStepProgress(step, slots.filter(slot => UtilsHelper.areObjectIdsEquals(slot.step._id, step._id))));
+  : exports.liveStepProgress(step, slots.filter(slot => UtilsHelper.areObjectIdsEquals(slot.step._id, step._id))));

--- a/tests/unit/helpers/steps.test.js
+++ b/tests/unit/helpers/steps.test.js
@@ -120,7 +120,7 @@ describe('elearningStepProgress', () => {
   });
 });
 
-describe('onSiteStepProgress', () => {
+describe('liveStepProgress', () => {
   let eLearningStepProgressStub;
   beforeEach(() => {
     eLearningStepProgressStub = sinon.stub(StepHelper, 'elearningStepProgress');
@@ -130,7 +130,7 @@ describe('onSiteStepProgress', () => {
     eLearningStepProgressStub.restore();
   });
 
-  it('should get on site steps progress', async () => {
+  it('should get live steps progress', async () => {
     const stepId = new ObjectID();
     const step = {
       _id: stepId,
@@ -142,12 +142,12 @@ describe('onSiteStepProgress', () => {
       { endDate: '2020-11-04T16:01:00.000Z', step: stepId },
     ];
 
-    const result = await StepHelper.onSiteStepProgress(step, slots);
+    const result = await StepHelper.liveStepProgress(step, slots);
     expect(result).toBe(1);
     sinon.assert.notCalled(eLearningStepProgressStub);
   });
 
-  it('should get on site steps progress with progress of elearning activities', async () => {
+  it('should get live steps progress with progress of elearning activities', async () => {
     const stepId = new ObjectID();
     const step = {
       _id: stepId,
@@ -161,7 +161,7 @@ describe('onSiteStepProgress', () => {
 
     eLearningStepProgressStub.returns(0.5);
 
-    const result = await StepHelper.onSiteStepProgress(step, slots);
+    const result = await StepHelper.liveStepProgress(step, slots);
     expect(result).toBe(0.95);
     sinon.assert.calledOnceWithExactly(eLearningStepProgressStub, step);
   });
@@ -176,7 +176,7 @@ describe('onSiteStepProgress', () => {
     const slots = [];
     eLearningStepProgressStub.returns(0.5);
 
-    const result = await StepHelper.onSiteStepProgress(step, slots);
+    const result = await StepHelper.liveStepProgress(step, slots);
 
     expect(result).toBe(0.05);
     sinon.assert.calledOnceWithExactly(eLearningStepProgressStub, step);
@@ -185,14 +185,14 @@ describe('onSiteStepProgress', () => {
 
 describe('getProgress', () => {
   let elearningStepProgress;
-  let onSiteStepProgress;
+  let liveStepProgress;
   beforeEach(() => {
     elearningStepProgress = sinon.stub(StepHelper, 'elearningStepProgress');
-    onSiteStepProgress = sinon.stub(StepHelper, 'onSiteStepProgress');
+    liveStepProgress = sinon.stub(StepHelper, 'liveStepProgress');
   });
   afterEach(() => {
     elearningStepProgress.restore();
-    onSiteStepProgress.restore();
+    liveStepProgress.restore();
   });
   it('should get progress for elearning step', async () => {
     const step = {
@@ -210,7 +210,7 @@ describe('getProgress', () => {
     sinon.assert.calledOnceWithExactly(elearningStepProgress, step);
   });
 
-  it('should get progress for on site step', async () => {
+  it('should get progress for live step', async () => {
     const stepId = new ObjectID();
     const step = {
       _id: stepId,
@@ -223,10 +223,10 @@ describe('getProgress', () => {
       { endDate: '2020-11-03T09:00:00.000Z', step: stepId },
       { endDate: '2020-11-04T16:01:00.000Z', step: stepId },
     ];
-    onSiteStepProgress.returns(1);
+    liveStepProgress.returns(1);
 
     const result = await StepHelper.getProgress(step, slots);
     expect(result).toBe(1);
-    sinon.assert.calledOnceWithExactly(onSiteStepProgress, step, slots);
+    sinon.assert.calledOnceWithExactly(liveStepProgress, step, slots);
   });
 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - ~~Ce n'est pas une ancienne route utilisée par les apps mobiles~~
      - [ ] J'ai bien fait les tests
  - C'est une ancienne route utilisée par une des apps mobiles
    -~~ J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)~~
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- Si mes changements impactent l'application formation :
  - [x] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [x] Affichage des pages explorer/mes formations/About/CourseProfile
    - [x] Inscription a une formation e-learning
    - [x] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME
- [x] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [x] Je n'ai pas changé les droits de la route
  - [x] Je n'ai pas changé les droits dans le fichier rights.js
  - [x] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [x] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - ~~Justification des breaking changes s'il y en a:~~
- ~~J'ai supprimé une route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- ~~J'ai renommé une route :~~
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- ~~J'ai ajouté un champ possible dans la route :~~
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- ~~J'ai rendu obligatoire un champs de la route :~~
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
-~~ J'ai retiré un champ possible dans la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- ~~J'ai supprimé un retour/un champs du retour de la route :~~
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

-~~ J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur/client/mobile

- Périmetre roles : coach/admin_client/admin_vendeur/rof/utilisateur_appmobile

- Cas d'usage : la progression sur une formation prend en compte les étapes distancielles (sur interface client/ interface vendeur / mobile)
