### PR TITLE
COM-2415 - Fix AML bug

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -13,7 +13,7 @@ const UtilsHelper = require('./utils');
 const NumbersHelper = require('./numbers');
 const PdfHelper = require('./pdf');
 const BillPdf = require('../data/pdf/billing/bill');
-const { HOURLY, THIRD_PARTY, CIVILITY_LIST, COMPANI, AUTOMATIC, MANUAL } = require('./constants');
+const { HOURLY, THIRD_PARTY, CIVILITY_LIST, COMPANI, AUTOMATIC, MANUAL, ROUNDING_ERROR } = require('./constants');
 
 exports.formatBillNumber = (companyPrefixNumber, prefix, seq) =>
   `FACT-${companyPrefixNumber}${prefix}${seq.toString().padStart(5, '0')}`;
@@ -385,7 +385,9 @@ exports.formatBillDetailsForPdf = (bill) => {
 
   const totalCustomer = NumbersHelper.add(totalSubscription, totalBillingItem, totalSurcharge);
   const totalTPP = NumbersHelper.add(NumbersHelper.subtract(bill.netInclTaxes, totalCustomer), totalDiscount);
-  if (totalTPP < -0.01) formattedDetails.push({ name: 'Prise en charge du/des tiers(s) payeur(s)', total: totalTPP });
+  if (totalTPP < -ROUNDING_ERROR) {
+    formattedDetails.push({ name: 'Prise en charge du/des tiers(s) payeur(s)', total: totalTPP });
+  }
 
   return {
     totalExclTaxes: UtilsHelper.formatPrice(totalExclTaxes),

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -223,6 +223,7 @@ module.exports = {
     };
   },
   AUTOMATIC: 'automatic',
+  ROUNDING_ERROR: 0.01,
   // SERVICE
   get SERVICE_NATURES() {
     return this.FUNDING_NATURES;


### PR DESCRIPTION
Fix d'un bug pour AML : https://compani.atlassian.net/browse/RC-564?atlOrigin=eyJpIjoiNTdkMDMwYTNjZGE4NDY4Mjk5ZGEyYjc2ZGVhNWM0YzMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : admin

- Cas d'usage : 
Pour reproduire le bug : 

Ajouter un bénéficiaire avec une souscription horaire à 23.05

Lui ajouter un évènement d’une durée de 1h10

Facturer ce bénéficiaire

La ligne ‘Prise en charge du/des tiers(s) payeur(s)’ ne doit pas apparaitre 