### PR TITLE
COM-2404: calculate netInclTaxes in backend

### DIFF
--- a/src/helpers/bills.js
+++ b/src/helpers/bills.js
@@ -275,8 +275,14 @@ exports.formatAndCreateBill = async (payload, credentials) => {
     .find({ _id: { $in: billingItemList.map(bi => bi.billingItem) } }, { vat: 1, name: 1 })
     .lean();
 
+  let netInclTaxes = 0;
+  for (const bi of billingItemList) {
+    netInclTaxes = NumbersHelper.add(netInclTaxes, NumbersHelper.multiply(bi.count, bi.unitInclTaxes));
+  }
+
   const bill = {
-    ...pick(payload, ['date', 'customer', 'netInclTaxes']),
+    ...pick(payload, ['date', 'customer']),
+    netInclTaxes,
     type: MANUAL,
     number: exports.formatBillNumber(company.prefixNumber, billNumber.prefix, billNumber.seq),
     billingItemList: billingItemList.map(bi => exports.formatBillingItem(bi, bddBillingItemList)),

--- a/src/routes/bills.js
+++ b/src/routes/bills.js
@@ -174,7 +174,6 @@ exports.plugin = {
               unitInclTaxes: Joi.number().required(),
               count: Joi.number().required(),
             })),
-            netInclTaxes: Joi.number().required(),
           }),
         },
         pre: [{ method: authorizeBillCreation }],

--- a/src/routes/preHandlers/bills.js
+++ b/src/routes/preHandlers/bills.js
@@ -124,9 +124,5 @@ exports.authorizeBillCreation = async (req) => {
     .countDocuments({ _id: { $in: billingItemIds }, company: companyId, type: MANUAL });
   if (billingItems !== billingItemIds.length) throw Boom.forbidden();
 
-  const totalInclTaxes = req.payload.billingItemList
-    .reduce((acc, current) => acc + current.unitInclTaxes * current.count, 0);
-  if (totalInclTaxes !== req.payload.netInclTaxes) throw Boom.forbidden();
-
   return null;
 };

--- a/tests/integration/bills.test.js
+++ b/tests/integration/bills.test.js
@@ -813,7 +813,6 @@ describe('BILL ROUTES - POST /bills', () => {
         customer: billCustomerList[0]._id,
         date: new Date('2021-09-02T20:00:00'),
         billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-        netInclTaxes: 30,
       };
       const response = await app.inject({
         method: 'POST',
@@ -828,14 +827,13 @@ describe('BILL ROUTES - POST /bills', () => {
       expect(billsCount).toBe(1 + authBillList.length);
     });
 
-    const missingParams = ['customer', 'date', 'netInclTaxes'];
+    const missingParams = ['customer', 'date'];
     missingParams.forEach((param) => {
       it(`should return 400 as ${param} is missing`, async () => {
         const payload = {
           customer: billCustomerList[0]._id,
           date: new Date('2021-09-02T20:00:00'),
           billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-          netInclTaxes: 30,
         };
         const response = await app.inject({
           method: 'POST',
@@ -856,7 +854,6 @@ describe('BILL ROUTES - POST /bills', () => {
           customer: billCustomerList[0]._id,
           date: new Date('2021-09-02T20:00:00'),
           billingItemList: [billingItem],
-          netInclTaxes: 30,
         };
         const response = await app.inject({
           method: 'POST',
@@ -874,7 +871,6 @@ describe('BILL ROUTES - POST /bills', () => {
         customer: new ObjectID(),
         date: new Date('2021-09-02T20:00:00'),
         billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-        netInclTaxes: 30,
       };
       const response = await app.inject({
         method: 'POST',
@@ -894,27 +890,6 @@ describe('BILL ROUTES - POST /bills', () => {
           { billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 },
           { billingItem: new ObjectID(), unitInclTaxes: 15, count: 2 },
         ],
-        netInclTaxes: 60,
-      };
-      const response = await app.inject({
-        method: 'POST',
-        url: '/bills',
-        payload,
-        headers: { Cookie: `alenvi_token=${authToken}` },
-      });
-
-      expect(response.statusCode).toBe(403);
-    });
-
-    it('should return 403 if netInclTaxes has incorrect amount', async () => {
-      const payload = {
-        customer: billCustomerList[0]._id,
-        date: new Date('2021-09-02T20:00:00'),
-        billingItemList: [
-          { billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 },
-          { billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 },
-        ],
-        netInclTaxes: 34.5,
       };
       const response = await app.inject({
         method: 'POST',
@@ -931,7 +906,6 @@ describe('BILL ROUTES - POST /bills', () => {
         customer: billCustomerList[0]._id,
         date: new Date('2021-09-02T20:00:00'),
         billingItemList: [{ billingItem: billingItemList[1]._id, unitInclTaxes: 15, count: 2 }],
-        netInclTaxes: 30,
       };
       const response = await app.inject({
         method: 'POST',
@@ -948,7 +922,6 @@ describe('BILL ROUTES - POST /bills', () => {
         customer: billCustomerList[3]._id,
         date: new Date('2021-09-02T20:00:00'),
         billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-        netInclTaxes: 30,
       };
       const response = await app.inject({
         method: 'POST',
@@ -968,7 +941,6 @@ describe('BILL ROUTES - POST /bills', () => {
         customer: billCustomerList[0]._id,
         date: new Date('2021-09-02T20:00:00'),
         billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-        netInclTaxes: 30,
       };
       const response = await app.inject({
         method: 'POST',
@@ -999,7 +971,6 @@ describe('BILL ROUTES - POST /bills', () => {
           customer: new ObjectID(),
           date: '2021-09-02T20:00:00',
           billingItemList: [{ billingItem: billingItemList[0]._id, unitInclTaxes: 15, count: 2 }],
-          netInclTaxes: 30,
         };
 
         const response = await app.inject({

--- a/tests/unit/helpers/bills.test.js
+++ b/tests/unit/helpers/bills.test.js
@@ -1919,7 +1919,6 @@ describe('formatAndCreateBill', () => {
         { billingItem: billingItemId1, unitInclTaxes: 10, count: 2 },
         { billingItem: billingItemId2, unitInclTaxes: 30, count: 1 },
       ],
-      netInclTaxes: 50,
     };
 
     getBillNumber.returns({ prefix: 'FACT-101', seq: 1 });


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  -~ Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - J'ai rendu obligatoire un champs :
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - J'ai retiré un champ possible :
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- J'ai changé une constante :
  - [x] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : client

- Périmetre roles : client_admin

- Cas d'usage : 
lorsque je créé une facture manuelle pour un beneficiaire, je n'ai plus la ligne Tiers-payeur sur la facture avec un montant de -0,00

POUR TESTER : 
facture manuelle à un bénéficaire avec 2 articles de facturation : 
PU TTC: 1,43 Volume: 7
PU TTC: 2, Volume: 8

