### PR TITLE
COM-2421: fix detach step bug

### DIFF
--- a/src/helpers/programs.js
+++ b/src/helpers/programs.js
@@ -46,7 +46,7 @@ exports.getProgram = async (programId) => {
   const program = await Program.findOne({ _id: programId })
     .populate({
       path: 'subPrograms',
-      populate: { path: 'steps', populate: [{ path: 'activities ', populate: 'cards' }, { path: 'courseSlotsCount' }] },
+      populate: { path: 'steps', populate: [{ path: 'activities ', populate: 'cards' }] },
     })
     .populate({ path: 'testers', select: 'identity.firstname identity.lastname local.email contact.phone' })
     .populate('categories')

--- a/src/models/Step.js
+++ b/src/models/Step.js
@@ -15,8 +15,6 @@ const StepSchema = mongoose.Schema({
 
 StepSchema.virtual('subPrograms', { ref: 'SubProgram', localField: '_id', foreignField: 'steps' });
 
-StepSchema.virtual('courseSlotsCount', { ref: 'CourseSlot', localField: '_id', foreignField: 'step', count: true });
-
 // eslint-disable-next-line consistent-return
 function setAreActivitiesValid() {
   const hasActivities = this.activities && this.activities.length !== 0;

--- a/tests/integration/seed/subProgramsSeed.js
+++ b/tests/integration/seed/subProgramsSeed.js
@@ -58,8 +58,8 @@ const subProgramsList = [
   { _id: new ObjectID(), name: 'subProgram 4', status: 'draft', steps: [stepsList[2]._id] },
   { _id: new ObjectID(), name: 'subProgram 5', status: 'published', steps: [stepsList[2]._id] },
   { _id: new ObjectID(), name: 'subProgram 6', status: 'draft', steps: [stepsList[3]._id] },
-  { _id: new ObjectID(), name: 'subProgram 7', status: 'draft', steps: [stepsList[4]._id] },
-  { _id: new ObjectID(), name: 'subProgram 8', status: 'draft', steps: [stepsList[0]._id, stepsList[5]] },
+  { _id: new ObjectID(), name: 'subProgram 7', status: 'draft', steps: [stepsList[4]._id, stepsList[5]._id] },
+  { _id: new ObjectID(), name: 'subProgram 8', status: 'draft', steps: [stepsList[0]._id, stepsList[5]._id] },
 ];
 
 const programsList = [
@@ -76,7 +76,7 @@ const programsList = [
 const coursesList = [{
   _id: new ObjectID(),
   format: 'strictly_e_learning',
-  subProgram: subProgramsList[4]._id,
+  subProgram: subProgramsList[7]._id,
   type: 'intra',
   company: new ObjectID(),
   salesRepresentative: vendorAdmin._id,

--- a/tests/integration/subPrograms.test.js
+++ b/tests/integration/subPrograms.test.js
@@ -492,7 +492,17 @@ describe('SUBPROGRAMS ROUTES - DELETE /subprograms/{_id}/step/{stepId}', () => {
       expect(response.statusCode).toBe(403);
     });
 
-    it('should return a 409 step is linked to a courseSlot', async () => {
+    it('should return a 200 if step is linked to a courseSlot but from another subprogram', async () => {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/subprograms/${subProgramsList[6]._id}/steps/${subProgramsList[6].steps[1]._id}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('should return a 409 step is linked to a courseSlot from subprogram', async () => {
       const response = await app.inject({
         method: 'DELETE',
         url: `/subprograms/${subProgramsList[7]._id}/steps/${subProgramsList[7].steps[1]._id}`,

--- a/tests/unit/helpers/programs.test.js
+++ b/tests/unit/helpers/programs.test.js
@@ -173,11 +173,7 @@ describe('getProgram', () => {
         {
           query: 'populate',
           args: [{
-            path: 'subPrograms',
-            populate: {
-              path: 'steps',
-              populate: [{ path: 'activities ', populate: 'cards' }, { path: 'courseSlotsCount' }],
-            },
+            path: 'subPrograms', populate: { path: 'steps', populate: [{ path: 'activities ', populate: 'cards' }] },
           }],
         },
         {


### PR DESCRIPTION
### TESTS
- [x] Mon code est testé unitairement

- Tests intégrations :
  - Ce n'est pas une ancienne route utilisée par les apps mobiles
      - [x] J'ai bien fait les tests
  - ~~C'est une ancienne route utilisée par une des apps mobiles~~
    - J'ai changé ce qu'acceptait ou ce que renvoyait la route (noms de champs, format, conditions)
      - [ ] J'ai fait de nouveaux tests sans modifier les anciens pour s'assurer que les anciennes versions des
      apps mobiles fonctionnent

### FONCTIONNALITÉS APPS MOBILES
- ~~Si mes changements impactent l'application formation :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours (a minima):
    - [ ] Affichage des pages explorer/mes formations/About/CourseProfile
    - [ ] Inscription a une formation e-learning
    - [ ] Possibilité de faire une activité

- ~~Si mes changements impactent l'application erp :~~
  - [ ] J'ai testé que les anciennes versions maintenues fonctionnent toujours

### MODIFICATIONS SUR LES ROUTES IMPACTANT UNE AUTRE PLATEFORME -np
- [ ] J'ai décrit dans le cas d'usage les choses à tester sur l'autre plateforme
- Je n'ai pas fait de breaking change :
  - [ ] Je n'ai pas changé les droits de la route
  - [ ] Je n'ai pas changé les droits dans le fichier rights.js
  - [ ] Je n'ai pas fait de changement sur le prehandler qui implique le mobile
  - [ ] Je n'ai pas changé le type d'un paramètre ou enlevé des valeurs possibles
  - Justification des breaking changes s'il y en a:
- J'ai supprimé une route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'utilisent pas
- J'ai renommé une route :
  - [ ] La route n'est pas utilisée par les apps mobiles 
    (si la route est utilisée en mobile: ne pas la renommer et plutôt créer une nouvelle route utilisée par la WEBAPP
    et toutes les nouvelles versions mobiles)
- J'ai ajouté un champ possible dans la route :
  - [ ] J'ai géré le cas ou on ne l'envoie pas
- J'ai rendu obligatoire un champs de la route :
  - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
- J'ai retiré un champ possible dans la route :
  - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas
- J'ai supprimé un retour/un champs du retour de la route :
  - [ ] Les anciennes versions mobiles + les actuelles n'utilisent pas ce retour

### MODIFICATIONS SUR LES MODÈLES
- ~~J'ai ajouté un modèle spécifique à une structure:~~
  - [ ] J'ai ajouté le champ company ainsi que les preHooks associés
- ~~J'ai changé un modèle utilisé par l'app mobile:~~
  - J'ai ajouté un champ possible :
    - [ ] J'ai géré le cas où l'application ne l'envoie pas
  - ~~J'ai rendu obligatoire un champs :~~
    - [ ] Il est toujours envoyé par les apps mobiles (même par les anciennes versions)
  - ~~J'ai retiré un champ possible :~~
    - [ ] Les anciennes versions mobiles + les actuelles ne l'envoient pas

### CONSTANTES ET VARIABLE D'ENV
- ~~J'ai changé une constante :~~
  - [ ] Elle n'est pas utilisée sur les apps mobiles (sinon on doit forcer la maj des apps)

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] J'ai précisé sur le slite de MES et MEP les modifications faites


### POUR TESTER LA PR
- Périmetre interface : vendeur

- Périmetre roles : rof/admin

- Cas d'usage : fix du bug de détachement des étapes : si une étape est rattachée à un sous-programme A utilisé dans une formation et qu'il y a un créneau pour cette étape, je peux tout de même détacher l'étape du sous-programme B qui n'a pas de créneau en lien avec cette étape