### PR TITLE
COM-4057: can send description only for trainer fees with percentage

### DIFF
--- a/src/routes/courseBills.js
+++ b/src/routes/courseBills.js
@@ -182,8 +182,8 @@ exports.plugin = {
         validate: {
           params: Joi.object({ _id: Joi.objectId().required(), billingPurchaseId: Joi.objectId().required() }),
           payload: Joi.object({
-            price: Joi.number().positive().required(),
-            count: Joi.number().positive().integer().required(),
+            price: Joi.number().positive(),
+            count: Joi.number().positive().integer(),
             description: Joi.string().allow(''),
           }),
         },

--- a/src/routes/preHandlers/courseBills.js
+++ b/src/routes/preHandlers/courseBills.js
@@ -292,8 +292,9 @@ exports.authorizeCourseBillingPurchaseUpdate = async (req) => {
     .find(p => UtilsHelper.areObjectIdsEquals(p._id, billingPurchaseId));
 
   const areFieldsChanged = payloadKeys.some(key => get(req.payload, key) !== get(purchase, key));
-  const isTrainerFeesWithPercentage = purchase.percentage &&
+  const isTrainerFeesWithPercentage = has(purchase, 'percentage') &&
     UtilsHelper.areObjectIdsEquals(purchase.billingItem, process.env.TRAINER_FEES_BILLING_ITEM);
+  if (!isTrainerFeesWithPercentage && !(req.payload.price || req.payload.count)) throw Boom.badRequest();
   if ((courseBillRelatedToPurchase.billedAt || isTrainerFeesWithPercentage) && areFieldsChanged) throw Boom.forbidden();
 
   return null;

--- a/src/routes/preHandlers/courseBills.js
+++ b/src/routes/preHandlers/courseBills.js
@@ -294,7 +294,7 @@ exports.authorizeCourseBillingPurchaseUpdate = async (req) => {
   const areFieldsChanged = payloadKeys.some(key => get(req.payload, key) !== get(purchase, key));
   const isTrainerFeesWithPercentage = has(purchase, 'percentage') &&
     UtilsHelper.areObjectIdsEquals(purchase.billingItem, process.env.TRAINER_FEES_BILLING_ITEM);
-  if (!isTrainerFeesWithPercentage && !(req.payload.price || req.payload.count)) throw Boom.badRequest();
+  if (!isTrainerFeesWithPercentage && !(req.payload.price && req.payload.count)) throw Boom.badRequest();
   if ((courseBillRelatedToPurchase.billedAt || isTrainerFeesWithPercentage) && areFieldsChanged) throw Boom.forbidden();
 
   return null;

--- a/tests/integration/courseBills.test.js
+++ b/tests/integration/courseBills.test.js
@@ -1939,7 +1939,7 @@ describe('COURSE BILL ROUTES - PUT /coursebills/{_id}/billingpurchases/{billingP
         method: 'PUT',
         url: `/coursebills/${billWithPercentageId}/billingpurchases/${trainerFeesWithPercentageId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { price: 12, count: 1, description: 'description' },
+        payload: { description: 'description' },
       });
 
       expect(response.statusCode).toBe(200);
@@ -1975,6 +1975,17 @@ describe('COURSE BILL ROUTES - PUT /coursebills/{_id}/billingpurchases/{billingP
 
         expect(response.statusCode).toBe(400);
       });
+    });
+
+    it('should return 400 if not trainer fees with percentage but price and count are missing in payload', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/coursebills/${courseBillId}/billingpurchases/${billingPurchaseId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { description: 'test' },
+      });
+
+      expect(response.statusCode).toBe(400);
     });
 
     it('should return 404 if course bill doesn\'t exist', async () => {

--- a/tests/integration/courseBills.test.js
+++ b/tests/integration/courseBills.test.js
@@ -1977,12 +1977,23 @@ describe('COURSE BILL ROUTES - PUT /coursebills/{_id}/billingpurchases/{billingP
       });
     });
 
-    it('should return 400 if not trainer fees with percentage but price and count are missing in payload', async () => {
+    it('should return 400 if not trainer fees with percentage but price is missing in payload', async () => {
       const response = await app.inject({
         method: 'PUT',
         url: `/coursebills/${courseBillId}/billingpurchases/${billingPurchaseId}`,
         headers: { Cookie: `alenvi_token=${authToken}` },
-        payload: { description: 'test' },
+        payload: { count: 1, description: 'test' },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it('should return 400 if not trainer fees with percentage but count is missing in payload', async () => {
+      const response = await app.inject({
+        method: 'PUT',
+        url: `/coursebills/${courseBillId}/billingpurchases/${billingPurchaseId}`,
+        headers: { Cookie: `alenvi_token=${authToken}` },
+        payload: { price: 12, description: 'test' },
       });
 
       expect(response.statusCode).toBe(400);


### PR DESCRIPTION
<details open><summary> TESTS  :computer: </summary>

- [ ] J'ai codé les tests unitaires -np
- [x] J'ai codé les tests d'intégration
- [ ] ~~C'est une ancienne route utilisée par les apps mobiles.~~
  - [ ] Si oui, J'ai fait de nouveaux tests sans modifier les anciens
</details>

- [ ] Je replie cette section car mes modifications n'ont pas besoin de tests unitaires ou d'intégration

---

<details><summary> POINTS D'ATTENTION POUR CETTE PR  :warning: </summary>

- [ ] J'ai fait des modifications sur une route utilisée sur plusieurs plateformes [Doc de détail](https://www.notion.so/Points-d-attention-sur-les-routes-a548a8e32d314d5e92cb342e66cce443)
- [ ] J'ai modifié un modèle utilisé en mobile [Doc de détail](https://www.notion.so/Point-d-attention-sur-les-mod-les-e46fbf180cd34a569f3c6102366e47ca)
- [ ] J'ai ajouté un modèle spécifique à une structure 
  - [ ] Si oui, j'ai ajouté le champs company ainsi que les prehooks associés
- [ ] J'ai ajouté/modifié une constante qui est utilisée sur les apps mobile
  - [ ] Si oui, j'ai précisé sur le [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) qu'il faut forcer la mise à jour
- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de MES](https://www.notion.so/Pas-pas-Mise-en-staging-01755ac57d944b4cb0c189861428e5d2) et [Doc de MEP](https://www.notion.so/Pas-pas-Mise-en-prod-0f8e4879217d4c9e8e4d46d44211e0e3) les modifications faites

</details>

- [x] Je replie cette section car je n'ai pas fait de modifications entrainant un point d'attention

---

<details><summary> FONCTIONNALITÉS APPS MOBILES  :iphone: </summary>

- [ ] Mes changements impactent l'application formation
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours
- [ ] Mes changements impactent l'application erp
  - [ ] Si oui, j'ai testé que les anciennes versions maintenues fonctionnent toujours

</details>

- [x] Je replie cette section car mes modifications n'ont pas d'impact sur les applications mobiles

_Si tu as lu cette description, pense à réagir avec un :eye:_
